### PR TITLE
FontAwesome5.SvgAwesome.Foreground' threw an exception. when setting Foreground

### DIFF
--- a/src/FontAwesome5.Net40/SvgAwesome.cs
+++ b/src/FontAwesome5.Net40/SvgAwesome.cs
@@ -185,13 +185,13 @@ namespace FontAwesome5
 
             if (svgAwesome == null) return;
 
-            if ((EFontAwesomeIcon)e.NewValue == EFontAwesomeIcon.None)
+            if (svgAwesome.Icon == EFontAwesomeIcon.None)
             {
                 svgAwesome.Child = null;
             }
             else
             {                
-                svgAwesome.Child = CreatePath((EFontAwesomeIcon)e.NewValue, svgAwesome.Foreground);
+                svgAwesome.Child = CreatePath(svgAwesome.Icon, svgAwesome.Foreground);
             }            
         }
 

--- a/src/FontAwesome5.NetCore30/SvgAwesome.cs
+++ b/src/FontAwesome5.NetCore30/SvgAwesome.cs
@@ -185,13 +185,13 @@ namespace FontAwesome5
 
             if (svgAwesome == null) return;
 
-            if ((EFontAwesomeIcon)e.NewValue == EFontAwesomeIcon.None)
+            if (svgAwesome.Icon == EFontAwesomeIcon.None)
             {
                 svgAwesome.Child = null;
             }
             else
             {
-                svgAwesome.Child = CreatePath((EFontAwesomeIcon)e.NewValue, svgAwesome.Foreground);
+                svgAwesome.Child = CreatePath(svgAwesome.Icon, svgAwesome.Foreground);
             }
         }
 


### PR DESCRIPTION
Since 2.0.3 you are unable to set the Foreground property of an SvgAwesome. 

This is just small fix to rectify the issue; it appears that the culprit was the fact that the Icon and Foreground dependency properties both call the same OnIconPropertyChanged method and the value is cast explicitly to a EFontAwesomeIcon when it will be a Brush if the Foreground changed.