### PR TITLE
Filter search box for example app icon lists.

### DIFF
--- a/src/Examples/FontAwesome5.Net40.Example/MainWindow.xaml
+++ b/src/Examples/FontAwesome5.Net40.Example/MainWindow.xaml
@@ -3,9 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:FontAwesome5.Net40.Example"
         xmlns:fa5="http://schemas.fontawesome.com/icons/"
+        xmlns:viewModels="clr-namespace:FontAwesome5.Net40.Example.ViewModels"
         mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}"
         Title="FontAwesome5.Net40.Example" SizeToContent="WidthAndHeight">
   <Window.Resources>
     <fa5:LabelConverter x:Key="LabelConverter"/>
@@ -62,22 +63,35 @@
       </StackPanel>
     </StackPanel>
 
-    <ListView Grid.Column="0" Grid.Row="1" ItemsSource="{Binding AllIcons}" SelectedItem="{Binding SelectedIcon}">
-      <ListView.View>
-        <GridView>
-          <GridViewColumn Header="Icon">
-            <GridViewColumn.CellTemplate>
-              <DataTemplate>
-                <fa5:ImageAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
-              </DataTemplate>
-            </GridViewColumn.CellTemplate>
-          </GridViewColumn>
-          <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Converter={StaticResource LabelConverter}}"/>
-          <GridViewColumn Header="Style" DisplayMemberBinding="{Binding Converter={StaticResource StyleConverter}}"/>
-        </GridView>
-      </ListView.View>
-    </ListView>
-
+    <Grid Grid.Column="0" Grid.Row="1">
+      <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition />
+      </Grid.ColumnDefinitions>
+      <TextBlock Text="Filter:  " Grid.Column="0" Grid.Row="0" Margin="5,0,0,5" />
+      <TextBox Grid.Column="1" Grid.Row="0" ToolTip ="String or Regex.."  Margin="0, 0, 0, 5"
+               Text="{Binding FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+      <ListView Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding VisibleIcons}" SelectedItem="{Binding SelectedIcon}">
+          <ListView.View>
+              <GridView>
+                  <GridViewColumn Header="Icon">
+                      <GridViewColumn.CellTemplate>
+                          <DataTemplate>
+                              <fa5:ImageAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
+                          </DataTemplate>
+                      </GridViewColumn.CellTemplate>
+                  </GridViewColumn>
+                  <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Converter={StaticResource LabelConverter}}"/>
+                  <GridViewColumn Header="Style" DisplayMemberBinding="{Binding Converter={StaticResource StyleConverter}}"/>
+              </GridView>
+          </ListView.View>
+      </ListView>
+    </Grid>
+      
     <StackPanel Grid.Column="1" Grid.Row="1">
 
       <fa5:SvgAwesome Icon="{Binding SelectedIcon}" Height="100" Width="100" Spin="{Binding SpinIsEnabled}" SpinDuration="{Binding SpinDuration}" Pulse="{Binding PulseIsEnabled}" PulseDuration="{Binding PulseDuration}" FlipOrientation="{Binding FlipOrientation}" Rotation="{Binding Rotation}"  Visibility="{Binding Visibility}" Margin="10"/>

--- a/src/Examples/FontAwesome5.Net40.Example/ViewModels/MainWindowViewModel.cs
+++ b/src/Examples/FontAwesome5.Net40.Example/ViewModels/MainWindowViewModel.cs
@@ -3,8 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using System.Windows;
 
 namespace FontAwesome5.Net40.Example.ViewModels
@@ -17,7 +16,7 @@ namespace FontAwesome5.Net40.Example.ViewModels
                         .OrderBy(i => i.GetStyle()).ThenBy(i => i.GetLabel()).ToList();
 
             AllIcons.Remove(EFontAwesomeIcon.None);
-            SelectedIcon = AllIcons.First();
+            UpdateVisibleIcons();
 
             FlipOrientations = Enum.GetValues(typeof(EFlipOrientation)).Cast<EFlipOrientation>().ToList();
             SpinDuration = 5;
@@ -46,5 +45,47 @@ namespace FontAwesome5.Net40.Example.ViewModels
         public List<EFontAwesomeIcon> AllIcons { get; set; } = new List<EFontAwesomeIcon>();
 
         public event PropertyChangedEventHandler PropertyChanged;
-    }
+
+        #region Visible Icon Filtering
+
+        public List<EFontAwesomeIcon> VisibleIcons { get; private set; }
+
+        public string FilterText { get; set; }
+
+        private void OnFilterTextChanged()
+        {
+          UpdateVisibleIcons();
+        }
+
+        private void UpdateVisibleIcons()
+        {
+          var addAll = string.IsNullOrWhiteSpace(FilterText);
+
+          //Confirm regex is valid
+          if (!addAll)
+          {
+            try
+            {
+              _ = Regex.IsMatch(string.Empty, FilterText);
+            }
+            catch (Exception)
+            {
+              addAll = true;
+            }
+          }
+
+          //Add all if no proper filter is applied
+          VisibleIcons = addAll
+            ? AllIcons
+            : new List<EFontAwesomeIcon>(AllIcons.Where(icon => Regex.IsMatch(
+              icon.GetInformation().Label
+              , FilterText
+              , RegexOptions.IgnoreCase
+            )));
+
+          SelectedIcon = VisibleIcons.FirstOrDefault();
+        }
+
+        #endregion
+  }
 }

--- a/src/Examples/FontAwesome5.NetCore.Example/MainWindow.xaml
+++ b/src/Examples/FontAwesome5.NetCore.Example/MainWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:FontAwesome5.NetCore30.Example"
         xmlns:fa5="http://schemas.fontawesome.com/icons/"
-        xmlns:fontawesome5="clr-namespace:FontAwesome5;assembly=FontAwesome5"
+        xmlns:viewModels="clr-namespace:FontAwesome5.NetCore30.Example.ViewModels"
         mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}"
         Title="FontAwesome5.NetCore.Example" Height="632" Width="883">
   <Window.Resources>
     <fa5:LabelConverter x:Key="LabelConverter"/>
@@ -63,21 +63,34 @@
       </StackPanel>
     </StackPanel>
 
-    <ListView Grid.Column="0" Grid.Row="1" ItemsSource="{Binding AllIcons}" SelectedItem="{Binding SelectedIcon}">
-      <ListView.View>
-        <GridView>
-          <GridViewColumn Header="Icon">
-            <GridViewColumn.CellTemplate>
-              <DataTemplate>
-                <fa5:ImageAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
-              </DataTemplate>
-            </GridViewColumn.CellTemplate>
-          </GridViewColumn>
-          <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Converter={StaticResource LabelConverter}}"/>
-          <GridViewColumn Header="Style" DisplayMemberBinding="{Binding Converter={StaticResource StyleConverter}}"/>
-        </GridView>
-      </ListView.View>
-    </ListView>
+    <Grid Grid.Column="0" Grid.Row="1">
+      <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition />
+      </Grid.ColumnDefinitions>
+      <TextBlock Text="Filter:  " Grid.Column="0" Grid.Row="0" Margin="5,0,0,5" />
+      <TextBox Grid.Column="1" Grid.Row="0" ToolTipService.ToolTip ="String or Regex.."  Margin="0, 0, 0, 5"
+               Text="{Binding FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+      <ListView Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding VisibleIcons}" SelectedItem="{Binding SelectedIcon}">
+          <ListView.View>
+              <GridView>
+                  <GridViewColumn Header="Icon">
+                      <GridViewColumn.CellTemplate>
+                          <DataTemplate>
+                              <fa5:ImageAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
+                          </DataTemplate>
+                      </GridViewColumn.CellTemplate>
+                  </GridViewColumn>
+                  <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Converter={StaticResource LabelConverter}}"/>
+                  <GridViewColumn Header="Style" DisplayMemberBinding="{Binding Converter={StaticResource StyleConverter}}"/>
+              </GridView>
+          </ListView.View>
+      </ListView>
+    </Grid>
 
     <StackPanel Grid.Column="1" Grid.Row="1">
       <fa5:SvgAwesome Icon="{Binding SelectedIcon}" Height="100" Width="100" Spin="{Binding SpinIsEnabled}" SpinDuration="{Binding SpinDuration}" Pulse="{Binding PulseIsEnabled}" PulseDuration="{Binding PulseDuration}" FlipOrientation="{Binding FlipOrientation}" Rotation="{Binding Rotation}" Visibility="{Binding Visibility}" Margin="10"/>

--- a/src/Examples/FontAwesome5.NetCore.Example/ViewModels/MainWindowViewModel.cs
+++ b/src/Examples/FontAwesome5.NetCore.Example/ViewModels/MainWindowViewModel.cs
@@ -4,8 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using System.Windows;
 
 namespace FontAwesome5.NetCore30.Example.ViewModels
@@ -17,7 +16,7 @@ namespace FontAwesome5.NetCore30.Example.ViewModels
       AllIcons = Enum.GetValues(typeof(EFontAwesomeIcon)).Cast<EFontAwesomeIcon>()
                   .OrderBy(i => i.GetStyle()).ThenBy(i => i.GetLabel()).ToList();
       AllIcons.Remove(EFontAwesomeIcon.None);
-      SelectedIcon = AllIcons.First();
+      UpdateVisibleIcons();
 
       FlipOrientations = Enum.GetValues(typeof(EFlipOrientation)).Cast<EFlipOrientation>().ToList();
       SpinDuration = 5;
@@ -46,5 +45,46 @@ namespace FontAwesome5.NetCore30.Example.ViewModels
     public List<EFontAwesomeIcon> AllIcons { get; set; } = new List<EFontAwesomeIcon>();
 
     public event PropertyChangedEventHandler PropertyChanged;
+
+    #region Visible Icon Filtering
+    
+    public List<EFontAwesomeIcon> VisibleIcons { get; private set; }
+
+    public string FilterText { get; set; }
+    private void OnFilterTextChanged()
+    {
+      UpdateVisibleIcons();
+    }
+
+    private void UpdateVisibleIcons()
+    {
+      var addAll = string.IsNullOrWhiteSpace(FilterText);
+
+      //Confirm regex is valid
+      if (!addAll)
+      {
+        try
+        {
+          _ = Regex.IsMatch(string.Empty, FilterText);
+        }
+        catch (Exception)
+        {
+          addAll = true;
+        }
+      }
+
+      //Add all if no proper filter is applied
+      VisibleIcons = addAll
+        ? AllIcons
+        : new List<EFontAwesomeIcon>(AllIcons.Where(icon => Regex.IsMatch(
+          icon.GetInformation().Label
+          , FilterText
+          , RegexOptions.IgnoreCase
+        )));
+
+      SelectedIcon = VisibleIcons.FirstOrDefault();
+    }
+
+    #endregion
   }
 }

--- a/src/Examples/FontAwesome5.UWP.Example/MainPage.xaml
+++ b/src/Examples/FontAwesome5.UWP.Example/MainPage.xaml
@@ -2,11 +2,12 @@
     x:Class="FontAwesome5.UWP.Example.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:FontAwesome5.UWP.Example"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:fa5="using:FontAwesome5"
+    xmlns:viewModels="clr-namespace:FontAwesome5.UWP.Example.ViewModels"
     mc:Ignorable="d"
+    d:DataContext="{d:DesignInstance viewModels:MainViewModel}"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
      
     <Grid>
@@ -44,17 +45,30 @@
             </StackPanel>
         </StackPanel>
 
-        <ListView Grid.Column="0" Grid.Row="1" ItemsSource="{Binding AllIcons}" 
-                  SelectedItem="{Binding SelectedIcon, Mode=TwoWay}">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <fa5:FontAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
-                        <TextBlock Text="{Binding}"></TextBlock>
-                    </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <Grid Grid.Column="0" Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Filter:  " Grid.Column="0" Grid.Row="0" Margin="5,0,0,5" />
+            <TextBox Grid.Column="1" Grid.Row="0" ToolTipService.ToolTip ="String or Regex.."  Margin="0, 0, 0, 5"
+                     Text="{Binding FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <ListView Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" ItemsSource="{Binding VisibleIcons}" 
+                      SelectedItem="{Binding SelectedIcon, Mode=TwoWay}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <fa5:FontAwesome Icon="{Binding}" Width="32" Height="32" Foreground="Black" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding}"></TextBlock>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </Grid>
 
         <StackPanel Grid.Column="1" Grid.Row="1">
             <Grid Margin="5">

--- a/src/Examples/FontAwesome5.UWP.Example/ViewModels/MainViewModel.cs
+++ b/src/Examples/FontAwesome5.UWP.Example/ViewModels/MainViewModel.cs
@@ -109,8 +109,6 @@ namespace FontAwesome5.UWP.Example.ViewModels
         }
 
         private double _rotation;
-        private string _filterText;
-
         public double Rotation
         {
             get => _rotation;
@@ -139,6 +137,7 @@ namespace FontAwesome5.UWP.Example.ViewModels
 
         public List<EFontAwesomeIcon> VisibleIcons { get; private set; }
 
+        private string _filterText;
         public string FilterText
         {
           get => _filterText;

--- a/src/Examples/FontAwesome5.UWP.Example/ViewModels/MainViewModel.cs
+++ b/src/Examples/FontAwesome5.UWP.Example/ViewModels/MainViewModel.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
+using System.Text.RegularExpressions;
 using FontAwesome5.Extensions;
-using FontAwesome5.UWP;
 
 namespace FontAwesome5.UWP.Example.ViewModels
 {
@@ -16,7 +15,7 @@ namespace FontAwesome5.UWP.Example.ViewModels
                         .OrderBy(i => i.GetStyle()).ThenBy(i => i.GetLabel()).ToList();
 
             AllIcons.Remove(EFontAwesomeIcon.None);
-            SelectedIcon = AllIcons.First();
+            UpdateVisibleIcons();
 
             FlipOrientations = Enum.GetValues(typeof(EFlipOrientation)).Cast<EFlipOrientation>().ToList();
             SpinDuration = 5;
@@ -110,6 +109,8 @@ namespace FontAwesome5.UWP.Example.ViewModels
         }
 
         private double _rotation;
+        private string _filterText;
+
         public double Rotation
         {
             get => _rotation;
@@ -125,7 +126,7 @@ namespace FontAwesome5.UWP.Example.ViewModels
         public List<EFontAwesomeIcon> AllIcons { get; set; } = new List<EFontAwesomeIcon>();
 
         public string FontText => $"<fa5:FontAwesome Icon=\"{SelectedIcon}\" Fontsize=\"{FontSize}\" Spin=\"{SpinIsEnabled}\" " + 
-                                  $"SpinDuration=\"{SpinDuration}\" Pulse=\"{PulseIsEnabled}\" PulseDuration=\"{PulseDuration}\" FlipOrientation=\"{FlipOrientation}\" Rotation=\"{Rotation}\" >";
+                                  $"SpinDuration=\"{SpinDuration}\" Pulse=\"{PulseIsEnabled}\" PulseDuration=\"{PulseDuration}\" FlipOrientation=\"{FlipOrientation}\" >";
 
         public void RaisePropertyChanged(string propertyName)
         {
@@ -133,5 +134,53 @@ namespace FontAwesome5.UWP.Example.ViewModels
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
-    }
+
+        #region Visible Icon Filtering
+
+        public List<EFontAwesomeIcon> VisibleIcons { get; private set; }
+
+        public string FilterText
+        {
+          get => _filterText;
+          set
+          {
+            _filterText = value;
+            UpdateVisibleIcons();
+          }
+        }
+
+        private void UpdateVisibleIcons()
+        {
+          var addAll = string.IsNullOrWhiteSpace(FilterText);
+
+          //Confirm regex is valid
+          if (!addAll)
+          {
+            try
+            {
+              _ = Regex.IsMatch(string.Empty, FilterText);
+            }
+            catch (Exception)
+            {
+              addAll = true;
+            }
+          }
+
+          //Add all if no proper filter is applied
+          VisibleIcons = addAll
+            ? AllIcons
+            : new List<EFontAwesomeIcon>(AllIcons.Where(icon => Regex.IsMatch(
+              icon.GetInformation().Label
+              , FilterText
+              , RegexOptions.IgnoreCase
+            )));
+
+          SelectedIcon = VisibleIcons.FirstOrDefault();
+
+          RaisePropertyChanged(nameof(VisibleIcons));
+          RaisePropertyChanged(nameof(SelectedIcon));
+        }
+
+        #endregion
+  }
 }


### PR DESCRIPTION
Hey guys.  Hope you are interested in a PR.  I like to use the example apps to find potential icons for our main app.  But the lack of search makes it a long process.  I added a search box to all three.  Can do regular string literals or regex.

BTW, I could not get the UWP app to compile without temporarily removing `Rotation="{Binding Rotation}"`.  Note sure if that is normal or something with my machine.  I didnt commit that so it is still there.

Let me know if you prefer a different format or branch strategy.

Thanks!
Ernie